### PR TITLE
Source and Decoder Fixes

### DIFF
--- a/trinnov_altitude/const.py
+++ b/trinnov_altitude/const.py
@@ -23,7 +23,7 @@ class UpmixerMode(Enum):
     MODE_NATIVE = ("native", "The Native upmixer mode.")
     MODE_LEGACY = ("legacy", "The Legacy upmixer mode.")
     MODE_UPMIX_ON_NATIVE = ("upmix_on_native", "The Upmix on Native upmixer mode.")
-    
+
     def __new__(cls, value, doc):
         obj = object.__new__(cls)
         obj._value_ = value

--- a/trinnov_altitude/const.py
+++ b/trinnov_altitude/const.py
@@ -16,14 +16,14 @@ class RemappingMode(Enum):
 
 
 class UpmixerMode(Enum):
-    MODE_AUTO = ("none", "Disable the remapping mode.")
-    MODE_AURO3D = ("none", "Disable the remapping mode.")
-    MODE_DTS = ("2D", "The 2D remapping mode.")
-    MODE_DOLBY = ("3D", "The 3D remapping mode.")
-    MODE_NATIVE = ("3D", "The 3D remapping mode.")
-    MODE_LEGACY = ("autorotate", "The autoratating remapping mode.")
-    MODE_UPMIX_ON_NATIVE = ("manual", "The manual remapping mode.")
-
+    MODE_AUTO = ("auto", "")
+    MODE_AURO3D = ("auro3d", "Auro 3D upmixer mode.")
+    MODE_DTS = ("dts", "DTS upmixer mode.")
+    MODE_DOLBY = ("dolby", "The Dolby upmixer mode.")
+    MODE_NATIVE = ("native", "The Native upmixer mode.")
+    MODE_LEGACY = ("legacy", "The Legacy upmixer mode.")
+    MODE_UPMIX_ON_NATIVE = ("upmix_on_native", "The Upmix on Native upmixer mode.")
+    
     def __new__(cls, value, doc):
         obj = object.__new__(cls)
         obj._value_ = value

--- a/trinnov_altitude/messages.py
+++ b/trinnov_altitude/messages.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import re
 
-# A-Z, 0-9, " " : -
-
 AUDIO_FORMAT_MAPPING = {
   "ATMOS TrueHD": "Dolby Atmos/Dolby TrueHD",
-  "TRUEHD": "Dolby TrueHD"
+  "DTS:X MA": "DTS:X Master Audio",
+  "DTS-HD MA": "DTS-HD Master Audio",
+  "ATMOS DD+": "Dolby Atmos/Dolby Digital Plus",
+  "DD": "Dolby Digital",
+  "TrueHD": "Dolby TrueHD"
 }
-
 
 def message_factory(message) -> Message:  # noqa: C901
     if match := re.match(r"^AUDIOSYNC\s(.*)", message):

--- a/trinnov_altitude/messages.py
+++ b/trinnov_altitude/messages.py
@@ -2,6 +2,13 @@ from __future__ import annotations
 
 import re
 
+# A-Z, 0-9, " " : -
+
+AUDIO_FORMAT_MAPPING = {
+  "ATMOS TrueHD": "Dolby Atmos/Dolby TrueHD",
+  "TRUEHD": "Dolby TrueHD"
+}
+
 
 def message_factory(message) -> Message:  # noqa: C901
     if match := re.match(r"^AUDIOSYNC\s(.*)", message):
@@ -30,6 +37,8 @@ def message_factory(message) -> Message:  # noqa: C901
         playable = bool(int(match.group(2)))
         decoder = match.group(3)
         upmixer = match.group(4)
+
+        decoder = AUDIO_FORMAT_MAPPING.get(decoder, decoder)
         return DecoderMessage(nonaudio, playable, decoder, upmixer)
     elif match := re.match(r"^DIM\s(-?\d+)", message):
         state = bool(int(match.group(1)))

--- a/trinnov_altitude/messages.py
+++ b/trinnov_altitude/messages.py
@@ -11,6 +11,7 @@ AUDIO_FORMAT_MAPPING = {
   "TrueHD": "Dolby TrueHD"
 }
 
+
 def message_factory(message) -> Message:  # noqa: C901
     if match := re.match(r"^AUDIOSYNC\s(.*)", message):
         mode = match.group(1)

--- a/trinnov_altitude/messages.py
+++ b/trinnov_altitude/messages.py
@@ -17,11 +17,14 @@ def message_factory(message) -> Message:  # noqa: C901
     elif match := re.match(r"^CURRENT_PROFILE\s(-?\d+)", message):
         state = int(match.group(1))
         return CurrentSourceMessage(state)
+    elif match := re.match(r"^META_PRESET_LOADED\s(-?\d+)", message):
+        state = int(match.group(1))
+        return CurrentSourceMessage(state)
     elif match := re.match(r"^CURRENT_SOURCE_FORMAT_NAME\s(.*)", message):
         format = match.group(1)
         return CurrentSourceFormat(format)
     elif match := re.match(
-        r"^DECODER NONAUDIO (\d+) PLAYABLE (\d+) DECODER ([\w\s]+) UPMIXER ([\w\s]+)", message
+        r"^DECODER NONAUDIO (\d+) PLAYABLE (\d+) DECODER (.*) UPMIXER (.*)", message
     ):
         nonaudio = bool(int(match.group(1)))
         playable = bool(int(match.group(2)))

--- a/trinnov_altitude/trinnov_altitude.py
+++ b/trinnov_altitude/trinnov_altitude.py
@@ -469,7 +469,7 @@ class TrinnovAltitude:
         Set the preset identified by `id`. Preset `0` is the built-in preset and
         presets >= `1` are user defined presets.
         """
-        await self._write(f"loadp Config_{id}", timeout)
+        await self._write(f"loadp Config_{id}.xml", timeout)
 
     async def quick_optimized_off(
         self, timeout: int | float | None = USE_DEFAULT_TIMEOUT

--- a/trinnov_altitude/trinnov_altitude.py
+++ b/trinnov_altitude/trinnov_altitude.py
@@ -469,7 +469,7 @@ class TrinnovAltitude:
         Set the preset identified by `id`. Preset `0` is the built-in preset and
         presets >= `1` are user defined presets.
         """
-        await self._write(f"loadp {id}", timeout)
+        await self._write(f"loadp Config_{id}", timeout)
 
     async def quick_optimized_off(
         self, timeout: int | float | None = USE_DEFAULT_TIMEOUT

--- a/trinnov_altitude/trinnov_altitude.py
+++ b/trinnov_altitude/trinnov_altitude.py
@@ -526,7 +526,7 @@ class TrinnovAltitude:
         """
         Set the source identified by `id`, where `0` is the first source.
         """
-        await self._write("profile {id}", timeout)
+        await self._write(f"profile {id}", timeout)
 
     async def source_set_by_name(
         self, name: str, timeout: int | float | None = USE_DEFAULT_TIMEOUT

--- a/trinnov_altitude/trinnov_altitude.py
+++ b/trinnov_altitude/trinnov_altitude.py
@@ -414,8 +414,7 @@ class TrinnovAltitude:
         """
         Toggle the mute state.
         """
-        await self._write("mute 2"
-                          , timeout)
+        await self._write("mute 2", timeout)
 
     async def page_adjust(
         self, delta: int, timeout: int | float | None = USE_DEFAULT_TIMEOUT
@@ -527,7 +526,7 @@ class TrinnovAltitude:
         """
         Set the source identified by `id`, where `0` is the first source.
         """
-        await self._write(f"profile {id}", timeout)
+        await self._write("profile {id}", timeout)
 
     async def source_set_by_name(
         self, name: str, timeout: int | float | None = USE_DEFAULT_TIMEOUT

--- a/trinnov_altitude/trinnov_altitude.py
+++ b/trinnov_altitude/trinnov_altitude.py
@@ -578,7 +578,7 @@ class TrinnovAltitude:
         Set the upmixer mode. See `const.UpmixerMode` for available options
         and descriptions.
         """
-        await self._write(f"remapping_mode {mode.value}", timeout)
+        await self._write(f"upmixer {mode.value}", timeout)
 
     async def volume_adjust(
         self, delta: int | float, timeout: int | float | None = USE_DEFAULT_TIMEOUT

--- a/trinnov_altitude/trinnov_altitude.py
+++ b/trinnov_altitude/trinnov_altitude.py
@@ -578,7 +578,7 @@ class TrinnovAltitude:
         Set the upmixer mode. See `const.UpmixerMode` for available options
         and descriptions.
         """
-        await self._write(f"upmixer {mode.value}", timeout)
+        await self._write(f"upmixer {const.UpmixerMode[mode].value}", timeout)
 
     async def volume_adjust(
         self, delta: int | float, timeout: int | float | None = USE_DEFAULT_TIMEOUT

--- a/trinnov_altitude/trinnov_altitude.py
+++ b/trinnov_altitude/trinnov_altitude.py
@@ -414,7 +414,8 @@ class TrinnovAltitude:
         """
         Toggle the mute state.
         """
-        await self._write("mute 2", timeout)
+        await self._write("mute 2"
+                          , timeout)
 
     async def page_adjust(
         self, delta: int, timeout: int | float | None = USE_DEFAULT_TIMEOUT
@@ -526,7 +527,7 @@ class TrinnovAltitude:
         """
         Set the source identified by `id`, where `0` is the first source.
         """
-        await self._write(f"profile 2", timeout)
+        await self._write(f"profile {id}", timeout)
 
     async def source_set_by_name(
         self, name: str, timeout: int | float | None = USE_DEFAULT_TIMEOUT

--- a/trinnov_altitude/trinnov_altitude.py
+++ b/trinnov_altitude/trinnov_altitude.py
@@ -469,7 +469,7 @@ class TrinnovAltitude:
         Set the preset identified by `id`. Preset `0` is the built-in preset and
         presets >= `1` are user defined presets.
         """
-        await self._write(f"loadp Config_{id}.xml", timeout)
+        await self._write(f"loadp {id}", timeout)
 
     async def quick_optimized_off(
         self, timeout: int | float | None = USE_DEFAULT_TIMEOUT
@@ -526,7 +526,7 @@ class TrinnovAltitude:
         """
         Set the source identified by `id`, where `0` is the first source.
         """
-        await self._write(f"profile {id}", timeout)
+        await self._write(f"profile 2", timeout)
 
     async def source_set_by_name(
         self, name: str, timeout: int | float | None = USE_DEFAULT_TIMEOUT


### PR DESCRIPTION
I've believe I've fixed the source and decoder issues.

For the source, when the source initially loads it uses the current preset message, but when it changes it uses the meta_preset_loaded message which is why it was working on initial load and not on source change.

For the decoder I've run a bunch of test files through the library and renamed what the message returns to what the trinnov interface and app display. I think I've caught them all but if you find more they just need a mapping.

If you're happy to merge this in and create a release, please also bump the version the HA integration.